### PR TITLE
Lowering threshold for track seeded iteration to 1GeV and treatment of seeds with no trackster

### DIFF
--- a/RecoHGCal/TICL/plugins/MultiClustersFromTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/MultiClustersFromTrackstersProducer.cc
@@ -66,32 +66,36 @@ void MultiClustersFromTrackstersProducer::produce(edm::Event& evt, const edm::Ev
   }
 
   std::for_each(std::begin(tracksters), std::end(tracksters), [&](auto const& trackster) {
-    std::array<double, 3> baricenter{{0., 0., 0.}};
-    double total_weight = 0.;
-    reco::HGCalMultiCluster temp;
-    int counter = 0;
-    std::for_each(std::begin(trackster.vertices), std::end(trackster.vertices), [&](unsigned int idx) {
-      temp.push_back(clusterPtrs[idx]);
-      auto fraction = 1.f / trackster.vertex_multiplicity[counter++];
-      for (auto const& cell : clusterPtrs[idx]->hitsAndFractions()) {
-        temp.addHitAndFraction(cell.first, cell.second * fraction);
-      }
-      auto weight = clusterPtrs[idx]->energy() * fraction;
-      total_weight += weight;
-      baricenter[0] += clusterPtrs[idx]->x() * weight;
-      baricenter[1] += clusterPtrs[idx]->y() * weight;
-      baricenter[2] += clusterPtrs[idx]->z() * weight;
-    });
-    std::transform(
-        std::begin(baricenter), std::end(baricenter), std::begin(baricenter), [&total_weight](double val) -> double {
-          return val / total_weight;
-        });
-    temp.setEnergy(total_weight);
-    temp.setCorrectedEnergy(total_weight);
-    temp.setPosition(math::XYZPoint(baricenter[0], baricenter[1], baricenter[2]));
-    temp.setAlgoId(reco::CaloCluster::hgcal_em);
-    temp.setTime(trackster.time, trackster.timeError);
-    multiclusters->push_back(temp);
+    // Do not create a multicluster if the trackster has no layer clusters.
+    // This could happen when a seed leads to no trackster and a dummy one is produced.
+    if(!trackster.vertices.empty()) {
+      std::array<double, 3> baricenter{{0., 0., 0.}};
+      double total_weight = 0.;
+      reco::HGCalMultiCluster temp;
+      int counter = 0;
+      std::for_each(std::begin(trackster.vertices), std::end(trackster.vertices), [&](unsigned int idx) {
+        temp.push_back(clusterPtrs[idx]);
+        auto fraction = 1.f / trackster.vertex_multiplicity[counter++];
+        for (auto const& cell : clusterPtrs[idx]->hitsAndFractions()) {
+          temp.addHitAndFraction(cell.first, cell.second * fraction);
+        }
+        auto weight = clusterPtrs[idx]->energy() * fraction;
+        total_weight += weight;
+        baricenter[0] += clusterPtrs[idx]->x() * weight;
+        baricenter[1] += clusterPtrs[idx]->y() * weight;
+        baricenter[2] += clusterPtrs[idx]->z() * weight;
+      });
+      std::transform(
+          std::begin(baricenter), std::end(baricenter), std::begin(baricenter), [&total_weight](double val) -> double {
+            return val / total_weight;
+          });
+      temp.setEnergy(total_weight);
+      temp.setCorrectedEnergy(total_weight);
+      temp.setPosition(math::XYZPoint(baricenter[0], baricenter[1], baricenter[2]));
+      temp.setAlgoId(reco::CaloCluster::hgcal_em);
+      temp.setTime(trackster.time, trackster.timeError);
+      multiclusters->push_back(temp);
+    }
   });
 
   evt.put(std::move(multiclusters), label_);

--- a/RecoHGCal/TICL/plugins/MultiClustersFromTrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/MultiClustersFromTrackstersProducer.cc
@@ -68,7 +68,7 @@ void MultiClustersFromTrackstersProducer::produce(edm::Event& evt, const edm::Ev
   std::for_each(std::begin(tracksters), std::end(tracksters), [&](auto const& trackster) {
     // Do not create a multicluster if the trackster has no layer clusters.
     // This could happen when a seed leads to no trackster and a dummy one is produced.
-    if(!trackster.vertices.empty()) {
+    if (!trackster.vertices.empty()) {
       std::array<double, 3> baricenter{{0., 0., 0.}};
       double total_weight = 0.;
       reco::HGCalMultiCluster temp;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionAlgoBase.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionAlgoBase.h
@@ -46,7 +46,7 @@ namespace ticl {
           : ev(eV), es(eS), layerClusters(lC), mask(mS), layerClustersTime(lT), tiles(tL), regions(rG) {}
     };
 
-    virtual void makeTracksters(const Inputs& input, std::vector<Trackster>& result) = 0;
+    virtual void makeTracksters(const Inputs& input, std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) = 0;
 
     enum VerbosityLevel { None = 0, Basic, Advanced, Expert, Guru };
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionAlgoBase.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionAlgoBase.h
@@ -46,7 +46,7 @@ namespace ticl {
           : ev(eV), es(eS), layerClusters(lC), mask(mS), layerClustersTime(lT), tiles(tL), regions(rG) {}
     };
 
-    virtual void makeTracksters(const Inputs& input, std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) = 0;
+    virtual void makeTracksters(const Inputs& input, std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) = 0;
 
     enum VerbosityLevel { None = 0, Basic, Advanced, Expert, Guru };
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionAlgoBase.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionAlgoBase.h
@@ -46,7 +46,9 @@ namespace ticl {
           : ev(eV), es(eS), layerClusters(lC), mask(mS), layerClustersTime(lT), tiles(tL), regions(rG) {}
     };
 
-    virtual void makeTracksters(const Inputs& input, std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) = 0;
+    virtual void makeTracksters(const Inputs& input,
+                                std::vector<Trackster>& result,
+                                std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) = 0;
 
     enum VerbosityLevel { None = 0, Basic, Advanced, Expert, Guru };
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -46,7 +46,7 @@ PatternRecognitionbyCA::~PatternRecognitionbyCA(){};
 
 void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::Inputs &input,
                                             std::vector<Trackster> &result, 
-                                            std::map<int, std::vector<int>>& seedToTracksterAssociation) {
+                                            std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) {
   // Protect from events with no seeding regions
   if(input.regions.empty()) return;
   
@@ -171,6 +171,9 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
 
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, result);
+
+  // now adding dummy tracksters from seeds not connected to any shower in the result collection
+  // these are marked as charged hadrons with probability 1.
   emptyTrackstersFromSeedsTRK(result, seedToTracksterAssociation, input.regions[0].collectionID);
 
   if (algo_verbosity_ > Advanced) {
@@ -188,7 +191,7 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
 void PatternRecognitionbyCA::mergeTrackstersTRK(const std::vector<Trackster> &input,
                                                 const std::vector<reco::CaloCluster> &layerClusters,
                                                 std::vector<Trackster> &output, 
-                                                std::map<int, std::vector<int>>& seedToTracksterAssociation) const {
+                                                std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) const {
 
   output.reserve(input.size());
   for (auto& thisSeed : seedToTracksterAssociation)
@@ -227,7 +230,7 @@ void PatternRecognitionbyCA::mergeTrackstersTRK(const std::vector<Trackster> &in
 
 
 void PatternRecognitionbyCA::emptyTrackstersFromSeedsTRK(std::vector<Trackster> & tracksters,
-    std::map<int, std::vector<int>>& seedToTracksterAssociation,
+    std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation,
     const edm::ProductID& collectionID) const
 {
   for (auto& thisSeed : seedToTracksterAssociation)

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -18,6 +18,7 @@ PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf, co
     : PatternRecognitionAlgoBase(conf, cache),
       theGraph_(std::make_unique<HGCGraph>()),
       oneTracksterPerTrackSeed_(conf.getParameter<bool>("oneTracksterPerTrackSeed")),
+      promoteEmptyRegionToTrackster_(conf.getParameter<bool>("promoteEmptyRegionToTrackster")),
       out_in_dfs_(conf.getParameter<bool>("out_in_dfs")),
       max_out_in_hops_(conf.getParameter<int>("max_out_in_hops")),
       min_cos_theta_(conf.getParameter<double>("min_cos_theta")),
@@ -174,8 +175,10 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
 
   // now adding dummy tracksters from seeds not connected to any shower in the result collection
   // these are marked as charged hadrons with probability 1.
-  emptyTrackstersFromSeedsTRK(result, seedToTracksterAssociation, input.regions[0].collectionID);
-
+  if(promoteEmptyRegionToTrackster_) {
+    emptyTrackstersFromSeedsTRK(result, seedToTracksterAssociation, input.regions[0].collectionID);
+  }
+  
   if (algo_verbosity_ > Advanced) {
     for (auto &trackster : result) {
       LogDebug("HGCPatternRecoByCA") << "Trackster characteristics: " << std::endl;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -47,6 +47,9 @@ PatternRecognitionbyCA::~PatternRecognitionbyCA(){};
 void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::Inputs &input,
                                             std::vector<Trackster> &result, 
                                             std::map<int, std::vector<int>>& seedToTracksterAssociation) {
+  // Protect from events with no seeding regions
+  if(input.regions.empty()) return;
+  
   rhtools_.getEventSetup(input.es);
 
   theGraph_->setVerbosity(algo_verbosity_);
@@ -55,7 +58,7 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
     LogDebug("HGCPatternRecoByCA") << "Making Tracksters with CA" << std::endl;
   }
 
-  bool isRegionalIter = (input.regions[0].collectionID != edm::ProductID{0,0});
+  bool isRegionalIter = (input.regions[0].index != -1);
   std::vector<HGCDoublet::HGCntuplet> foundNtuplets;
   std::vector<int> seedIndices;
   std::vector<uint8_t> layer_cluster_usage(input.layerClusters.size(), 0);

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -45,11 +45,12 @@ PatternRecognitionbyCA::PatternRecognitionbyCA(const edm::ParameterSet &conf, co
 PatternRecognitionbyCA::~PatternRecognitionbyCA(){};
 
 void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::Inputs &input,
-                                            std::vector<Trackster> &result, 
-                                            std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) {
+                                            std::vector<Trackster> &result,
+                                            std::unordered_map<int, std::vector<int>> &seedToTracksterAssociation) {
   // Protect from events with no seeding regions
-  if(input.regions.empty()) return;
-  
+  if (input.regions.empty())
+    return;
+
   rhtools_.getEventSetup(input.es);
 
   theGraph_->setVerbosity(algo_verbosity_);
@@ -135,8 +136,7 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
     //if a seeding region does not lead to any trackster
     tmp.seedID = input.regions[0].collectionID;
     tmp.seedIndex = seedIndices[tracksterId];
-    if(isRegionalIter) 
-    {
+    if (isRegionalIter) {
       seedToTracksterAssociation[tmp.seedIndex].push_back(tracksterId);
     }
 
@@ -188,39 +188,34 @@ void PatternRecognitionbyCA::makeTracksters(const PatternRecognitionAlgoBase::In
   }
 }
 
-void PatternRecognitionbyCA::mergeTrackstersTRK(const std::vector<Trackster> &input,
-                                                const std::vector<reco::CaloCluster> &layerClusters,
-                                                std::vector<Trackster> &output, 
-                                                std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) const {
-
+void PatternRecognitionbyCA::mergeTrackstersTRK(
+    const std::vector<Trackster> &input,
+    const std::vector<reco::CaloCluster> &layerClusters,
+    std::vector<Trackster> &output,
+    std::unordered_map<int, std::vector<int>> &seedToTracksterAssociation) const {
   output.reserve(input.size());
-  for (auto& thisSeed : seedToTracksterAssociation)
-  {
-    auto& tracksters = thisSeed.second;
-    if(!tracksters.empty())
-    {
+  for (auto &thisSeed : seedToTracksterAssociation) {
+    auto &tracksters = thisSeed.second;
+    if (!tracksters.empty()) {
       auto numberOfTrackstersInSeed = tracksters.size();
       output.emplace_back(input[tracksters[0]]);
-      auto& outTrackster = output.back();
-      tracksters[0] = output.size()-1;
+      auto &outTrackster = output.back();
+      tracksters[0] = output.size() - 1;
       auto updated_size = outTrackster.vertices.size();
-      for(unsigned int j = 1; j<numberOfTrackstersInSeed; ++j)
-      {
-        auto& thisTrackster = input[tracksters[j]];
+      for (unsigned int j = 1; j < numberOfTrackstersInSeed; ++j) {
+        auto &thisTrackster = input[tracksters[j]];
         updated_size += thisTrackster.vertices.size();
         if (algo_verbosity_ > Basic) {
           LogDebug("HGCPatternRecoByCA") << "Updated size: " << updated_size << std::endl;
-        }  
+        }
         outTrackster.vertices.reserve(updated_size);
         outTrackster.vertex_multiplicity.reserve(updated_size);
         std::copy(std::begin(thisTrackster.vertices),
-          std::end(thisTrackster.vertices),
-          std::back_inserter(outTrackster.vertices)
-          );
+                  std::end(thisTrackster.vertices),
+                  std::back_inserter(outTrackster.vertices));
         std::copy(std::begin(thisTrackster.vertex_multiplicity),
-          std::end(thisTrackster.vertex_multiplicity),
-          std::back_inserter(outTrackster.vertex_multiplicity)
-          );
+                  std::end(thisTrackster.vertex_multiplicity),
+                  std::back_inserter(outTrackster.vertex_multiplicity));
       }
       tracksters.resize(1);
     }
@@ -228,25 +223,22 @@ void PatternRecognitionbyCA::mergeTrackstersTRK(const std::vector<Trackster> &in
   output.shrink_to_fit();
 }
 
-
-void PatternRecognitionbyCA::emptyTrackstersFromSeedsTRK(std::vector<Trackster> & tracksters,
-    std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation,
-    const edm::ProductID& collectionID) const
-{
-  for (auto& thisSeed : seedToTracksterAssociation)
-  {
-    if(thisSeed.second.empty())
-    {
+void PatternRecognitionbyCA::emptyTrackstersFromSeedsTRK(
+    std::vector<Trackster> &tracksters,
+    std::unordered_map<int, std::vector<int>> &seedToTracksterAssociation,
+    const edm::ProductID &collectionID) const {
+  for (auto &thisSeed : seedToTracksterAssociation) {
+    if (thisSeed.second.empty()) {
       Trackster t;
       t.regressed_energy = 0.f;
       for (float &p : t.id_probabilities) {
-          p = 0.f;
+        p = 0.f;
       }
       t.id_probabilities[4] = 1.f;
       t.seedID = collectionID;
       t.seedIndex = thisSeed.first;
       tracksters.emplace_back(t);
-      thisSeed.second.emplace_back(tracksters.size()-1);
+      thisSeed.second.emplace_back(tracksters.size() - 1);
     }
   }
 }

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -16,14 +16,17 @@ namespace ticl {
     PatternRecognitionbyCA(const edm::ParameterSet& conf, const CacheBase* cache);
     ~PatternRecognitionbyCA() override;
 
-    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result) override;
+    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) override;
 
     void energyRegressionAndID(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& result);
-
+    void emptyTrackstersFromSeedsTRK(std::vector<Trackster> & tracksters,
+      std::map<int, std::vector<int>>& seedToTracksterAssociation,
+      const edm::ProductID& collectionID) const;
   private:
     void mergeTrackstersTRK(const std::vector<Trackster>&,
                             const std::vector<reco::CaloCluster>&,
-                            std::vector<Trackster>&) const;
+                            std::vector<Trackster>&, 
+                            std::map<int, std::vector<int>>& seedToTracksterAssociation) const;
     const std::unique_ptr<HGCGraph> theGraph_;
     const bool oneTracksterPerTrackSeed_;
     const bool out_in_dfs_;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -16,17 +16,17 @@ namespace ticl {
     PatternRecognitionbyCA(const edm::ParameterSet& conf, const CacheBase* cache);
     ~PatternRecognitionbyCA() override;
 
-    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) override;
+    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) override;
 
     void energyRegressionAndID(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& result);
     void emptyTrackstersFromSeedsTRK(std::vector<Trackster> & tracksters,
-      std::map<int, std::vector<int>>& seedToTracksterAssociation,
+      std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation,
       const edm::ProductID& collectionID) const;
   private:
     void mergeTrackstersTRK(const std::vector<Trackster>&,
                             const std::vector<reco::CaloCluster>&,
                             std::vector<Trackster>&, 
-                            std::map<int, std::vector<int>>& seedToTracksterAssociation) const;
+                            std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) const;
     const std::unique_ptr<HGCGraph> theGraph_;
     const bool oneTracksterPerTrackSeed_;
     const bool out_in_dfs_;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -16,16 +16,19 @@ namespace ticl {
     PatternRecognitionbyCA(const edm::ParameterSet& conf, const CacheBase* cache);
     ~PatternRecognitionbyCA() override;
 
-    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) override;
+    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input,
+                        std::vector<Trackster>& result,
+                        std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) override;
 
     void energyRegressionAndID(const std::vector<reco::CaloCluster>& layerClusters, std::vector<Trackster>& result);
-    void emptyTrackstersFromSeedsTRK(std::vector<Trackster> & tracksters,
-      std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation,
-      const edm::ProductID& collectionID) const;
+    void emptyTrackstersFromSeedsTRK(std::vector<Trackster>& tracksters,
+                                     std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation,
+                                     const edm::ProductID& collectionID) const;
+
   private:
     void mergeTrackstersTRK(const std::vector<Trackster>&,
                             const std::vector<reco::CaloCluster>&,
-                            std::vector<Trackster>&, 
+                            std::vector<Trackster>&,
                             std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) const;
     const std::unique_ptr<HGCGraph> theGraph_;
     const bool oneTracksterPerTrackSeed_;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.h
@@ -32,6 +32,7 @@ namespace ticl {
                             std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) const;
     const std::unique_ptr<HGCGraph> theGraph_;
     const bool oneTracksterPerTrackSeed_;
+    const bool promoteEmptyRegionToTrackster_ = true;
     const bool out_in_dfs_;
     const unsigned int max_out_in_hops_;
     const float min_cos_theta_;

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
@@ -2,6 +2,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 void ticl::PatternRecognitionbyMultiClusters::makeTracksters(const PatternRecognitionAlgoBase::Inputs& input,
-                                                             std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) {
+                                                             std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) {
   LogDebug("HGCPatterRecoTrackster") << "making Tracksters" << std::endl;
 }

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
@@ -2,6 +2,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 void ticl::PatternRecognitionbyMultiClusters::makeTracksters(const PatternRecognitionAlgoBase::Inputs& input,
-                                                             std::vector<Trackster>& result) {
+                                                             std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) {
   LogDebug("HGCPatterRecoTrackster") << "making Tracksters" << std::endl;
 }

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.cc
@@ -1,7 +1,9 @@
 #include "PatternRecognitionbyMultiClusters.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-void ticl::PatternRecognitionbyMultiClusters::makeTracksters(const PatternRecognitionAlgoBase::Inputs& input,
-                                                             std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) {
+void ticl::PatternRecognitionbyMultiClusters::makeTracksters(
+    const PatternRecognitionAlgoBase::Inputs& input,
+    std::vector<Trackster>& result,
+    std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) {
   LogDebug("HGCPatterRecoTrackster") << "making Tracksters" << std::endl;
 }

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
@@ -20,7 +20,9 @@ namespace ticl {
         : PatternRecognitionAlgoBase(conf, cache) {}
     ~PatternRecognitionbyMultiClusters() override{};
 
-    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) override;
+    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input,
+                        std::vector<Trackster>& result,
+                        std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) override;
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
@@ -20,7 +20,7 @@ namespace ticl {
         : PatternRecognitionAlgoBase(conf, cache) {}
     ~PatternRecognitionbyMultiClusters() override{};
 
-    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result) override;
+    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) override;
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyMultiClusters.h
@@ -20,7 +20,7 @@ namespace ticl {
         : PatternRecognitionAlgoBase(conf, cache) {}
     ~PatternRecognitionbyMultiClusters() override{};
 
-    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::map<int, std::vector<int>>& seedToTracksterAssociation) override;
+    void makeTracksters(const PatternRecognitionAlgoBase::Inputs& input, std::vector<Trackster>& result,  std::unordered_map<int, std::vector<int>>& seedToTracksterAssociation) override;
   };
 }  // namespace ticl
 #endif

--- a/RecoHGCal/TICL/plugins/TICLSeedingRegionProducer.cc
+++ b/RecoHGCal/TICL/plugins/TICLSeedingRegionProducer.cc
@@ -58,7 +58,7 @@ void TICLSeedingRegionProducer::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<int>("algo_verbosity", 0);
   desc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
   desc.add<std::string>("cutTk",
-                        "1.48 < abs(eta) < 3.0 && pt > 2. && quality(\"highPurity\") && "
+                        "1.48 < abs(eta) < 3.0 && pt > 1. && quality(\"highPurity\") && "
                         "hitPattern().numberOfLostHits(\"MISSING_OUTER_HITS\") < 10");
   desc.add<std::string>("propagator", "PropagatorWithMaterial");
   desc.add<int>("algoId", 1);

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -152,7 +152,8 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
 
 
   std::unordered_map<int, std::vector<int>> seedToTrackstersAssociation;
-  if(itername_=="TRK")
+  // if it's regional iteration and there are seeding regions
+  if(!seeding_regions.empty() and seeding_regions[0].index != -1)
   {
     auto numberOfSeedingRegions = seeding_regions.size();
     for(unsigned int i = 0; i< numberOfSeedingRegions; ++i)

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -151,7 +151,7 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
       evt, es, layerClusters, inputClusterMask, layerClustersTimes, layer_clusters_tiles, seeding_regions);
 
 
-  std::map<int, std::vector<int>> seedToTrackstersAssociation;
+  std::unordered_map<int, std::vector<int>> seedToTrackstersAssociation;
   if(itername_=="TRK")
   {
     auto numberOfSeedingRegions = seeding_regions.size();

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -150,15 +150,12 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   const ticl::PatternRecognitionAlgoBase::Inputs input(
       evt, es, layerClusters, inputClusterMask, layerClustersTimes, layer_clusters_tiles, seeding_regions);
 
-
   std::unordered_map<int, std::vector<int>> seedToTrackstersAssociation;
   // if it's regional iteration and there are seeding regions
-  if(!seeding_regions.empty() and seeding_regions[0].index != -1)
-  {
+  if (!seeding_regions.empty() and seeding_regions[0].index != -1) {
     auto numberOfSeedingRegions = seeding_regions.size();
-    for(unsigned int i = 0; i< numberOfSeedingRegions; ++i)
-    {
-      seedToTrackstersAssociation.emplace(seeding_regions[i].index,0);
+    for (unsigned int i = 0; i < numberOfSeedingRegions; ++i) {
+      seedToTrackstersAssociation.emplace(seeding_regions[i].index, 0);
     }
   }
   myAlgo_->makeTracksters(input, *result, seedToTrackstersAssociation);

--- a/RecoHGCal/TICL/plugins/TrackstersProducer.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersProducer.cc
@@ -149,7 +149,18 @@ void TrackstersProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   const auto& seeding_regions = *seeding_regions_h;
   const ticl::PatternRecognitionAlgoBase::Inputs input(
       evt, es, layerClusters, inputClusterMask, layerClustersTimes, layer_clusters_tiles, seeding_regions);
-  myAlgo_->makeTracksters(input, *result);
+
+
+  std::map<int, std::vector<int>> seedToTrackstersAssociation;
+  if(itername_=="TRK")
+  {
+    auto numberOfSeedingRegions = seeding_regions.size();
+    for(unsigned int i = 0; i< numberOfSeedingRegions; ++i)
+    {
+      seedToTrackstersAssociation.emplace(seeding_regions[i].index,0);
+    }
+  }
+  myAlgo_->makeTracksters(input, *result, seedToTrackstersAssociation);
 
   // Now update the global mask and put it into the event
   output_mask->reserve(original_layerclusters_mask_h->size());


### PR DESCRIPTION
#### PR description:

This PR includes 

- a map for associating seeds to tracksters. 
- if a seed is not associated to any trackster, an empty trackster is created
- the p_T threshold for tracking iteration is lowered to 1GeV/c


#### PR validation:
tested on wf D49 `23289.0`, `23288.0` and ttbar PU200