### PR TITLE
Trackster validation

### DIFF
--- a/Validation/Configuration/python/hgcalSimValid_cff.py
+++ b/Validation/Configuration/python/hgcalSimValid_cff.py
@@ -12,6 +12,9 @@ from Validation.RecoParticleFlow.PFJetValidation_cff import pfJetValidation1 as 
 from Validation.HGCalValidation.ticlPFValidation_cfi import ticlPFValidation
 hgcalTiclPFValidation = cms.Sequence(ticlPFValidation)
 
+from Validation.HGCalValidation.ticlTrackstersValidation_cfi import ticlTrackstersValidation
+hgcalTiclTrackstersValidationSequence = cms.Sequence(ticlTrackstersValidation)
+
 hgcalValidatorSequence = cms.Sequence(hgcalValidator)
 hgcalPFJetValidation = _hgcalPFJetValidation.clone(BenchmarkLabel = 'PFJetValidation/HGCAlCompWithGenJet',
     VariablePtBins=[10., 30., 80., 120., 250., 600.],
@@ -31,4 +34,5 @@ hgcalValidation = cms.Sequence(hgcalSimHitValidationEE
                                + hgcalHitValidationSequence
                                + hgcalValidatorSequence
                                + hgcalTiclPFValidation
+                               + hgcalTiclTrackstersValidationSequence
                                + hgcalPFJetValidation)

--- a/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
+++ b/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
@@ -63,6 +63,7 @@ void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
     edm::Handle<std::vector<Trackster>> trackster_h;
     iEvent.getByToken(trackster_token, trackster_h);
     auto numberOfTracksters = trackster_h->size();
+
     for (size_t i = 0; i < numberOfTracksters; ++i) {
       auto const& trackster = (*trackster_h)[i];
     }
@@ -78,13 +79,14 @@ void TICLTrackstersValidation::bookHistograms(DQMStore::IBooker& ibook,
 
 void TICLTrackstersValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  std::vector<edm::InputTag> source_vector{edm::InputTag("trackstersTrk"),
-                                           edm::InputTag("trackstersMIP"),
-                                           edm::InputTag("trackstersEM"),
-                                           edm::InputTag("trackstersHAD")};
+  std::vector<edm::InputTag> source_vector{edm::InputTag("ticlTrackstersTrk"),
+                                           edm::InputTag("ticlTrackstersMIP"),
+                                           edm::InputTag("ticlTrackstersEM"),
+                                           edm::InputTag("ticlTrackstersHAD"),
+                                           edm::InputTag("ticlTrackstersMerge")};
   desc.add<std::vector<edm::InputTag>>("tracksterCollections", source_vector);
   desc.add<std::string>("folder", "HGCAL/");  
-  descriptions.add("TICLTrackstersValidationDefault", desc);
+  descriptions.add("ticlTrackstersValidationDefault", desc);
 }
 
 DEFINE_FWK_MODULE(TICLTrackstersValidation);

--- a/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
+++ b/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
@@ -1,0 +1,90 @@
+#include <string>
+#include <unordered_map>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DQMServices/Core/interface/DQMGlobalEDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Utilities/interface/transform.h"
+#include "DataFormats/HGCalReco/interface/Trackster.h"
+
+using namespace ticl;
+using namespace edm;
+
+
+struct Histogram_TICLTrackstersValidation {
+  dqm::reco::MonitorElement* energy_;
+};
+
+using Histograms_TICLTrackstersValidation = std::unordered_map<int, Histogram_TICLTrackstersValidation>;
+
+class TICLTrackstersValidation : public DQMGlobalEDAnalyzer<Histograms_TICLTrackstersValidation> {
+public:
+  explicit TICLTrackstersValidation(const edm::ParameterSet&);
+  ~TICLTrackstersValidation() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void bookHistograms(DQMStore::IBooker&,
+                      edm::Run const&,
+                      edm::EventSetup const&,
+                      Histograms_TICLTrackstersValidation&) const override;
+
+  void dqmAnalyze(edm::Event const&, edm::EventSetup const&, Histograms_TICLTrackstersValidation const&) const override;
+
+  std::string folder_;
+  std::vector<edm::EDGetTokenT<std::vector<Trackster>>> trackster_tokens_;
+};
+
+
+TICLTrackstersValidation::TICLTrackstersValidation(const edm::ParameterSet& iConfig)
+    : folder_(iConfig.getParameter<std::string>("folder")){
+  trackster_tokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
+                            [this](edm::InputTag const& tag) { return consumes<std::vector<Trackster>>(tag); });
+     
+}
+
+TICLTrackstersValidation::~TICLTrackstersValidation() {
+}
+
+
+
+void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
+                                  edm::EventSetup const& iSetup,
+                                  Histograms_TICLTrackstersValidation const& histos) const {
+
+  for (auto& trackster_token : trackster_tokens_) {
+    edm::Handle<std::vector<Trackster>> trackster_h;
+    iEvent.getByToken(trackster_token, trackster_h);
+    auto numberOfTracksters = trackster_h->size();
+    for (size_t i = 0; i < numberOfTracksters; ++i) {
+      auto const& trackster = (*trackster_h)[i];
+    }
+  }
+}
+
+void TICLTrackstersValidation::bookHistograms(DQMStore::IBooker& ibook,
+                                      edm::Run const& run,
+                                      edm::EventSetup const& iSetup,
+                                      Histograms_TICLTrackstersValidation& histos) const {
+  ibook.setCurrentFolder(folder_ + "TICLTracksters/");
+}
+
+void TICLTrackstersValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  std::vector<edm::InputTag> source_vector{edm::InputTag("trackstersTrk"),
+                                           edm::InputTag("trackstersMIP"),
+                                           edm::InputTag("trackstersEM"),
+                                           edm::InputTag("trackstersHAD")};
+  desc.add<std::vector<edm::InputTag>>("tracksterCollections", source_vector);
+  desc.add<std::string>("folder", "HGCAL/");  
+  descriptions.add("TICLTrackstersValidationDefault", desc);
+}
+
+DEFINE_FWK_MODULE(TICLTrackstersValidation);

--- a/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
+++ b/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
@@ -16,10 +16,8 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
-
 using namespace ticl;
 using namespace edm;
-
 
 struct Histogram_TICLTrackstersValidation {
   dqm::reco::MonitorElement* energy_;
@@ -41,7 +39,7 @@ private:
                       Histograms_TICLTrackstersValidation&) const override;
 
   void dqmAnalyze(edm::Event const&, edm::EventSetup const&, Histograms_TICLTrackstersValidation const&) const override;
-  void dqmBeginRun(edm::Run const&, edm::EventSetup const&, Histograms_TICLTrackstersValidation &);
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&, Histograms_TICLTrackstersValidation&);
 
   std::string folder_;
   std::vector<edm::EDGetTokenT<std::vector<Trackster>>> tracksterTokens_;
@@ -49,23 +47,19 @@ private:
   hgcal::RecHitTools rhtools_;
 };
 
-
 TICLTrackstersValidation::TICLTrackstersValidation(const edm::ParameterSet& iConfig)
-    : folder_(iConfig.getParameter<std::string>("folder")){
-  tracksterTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
+    : folder_(iConfig.getParameter<std::string>("folder")) {
+  tracksterTokens_ =
+      edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
                             [this](edm::InputTag const& tag) { return consumes<std::vector<Trackster>>(tag); });
   layerClustersToken_ = consumes<std::vector<reco::CaloCluster>>(iConfig.getParameter<edm::InputTag>("layerClusters"));
 }
 
-TICLTrackstersValidation::~TICLTrackstersValidation() {
-}
-
-
+TICLTrackstersValidation::~TICLTrackstersValidation() {}
 
 void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
-                                  edm::EventSetup const& iSetup,
-                                  Histograms_TICLTrackstersValidation const& histos) const {
-
+                                          edm::EventSetup const& iSetup,
+                                          Histograms_TICLTrackstersValidation const& histos) const {
   edm::Handle<std::vector<reco::CaloCluster>> layerClustersH;
   iEvent.getByToken(layerClustersToken_, layerClustersH);
   auto const& layerClusters = *layerClustersH.product();
@@ -81,15 +75,16 @@ void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
 }
 
 void TICLTrackstersValidation::bookHistograms(DQMStore::IBooker& ibook,
-                                      edm::Run const& run,
-                                      edm::EventSetup const& iSetup,
-                                      Histograms_TICLTrackstersValidation& histos) const {
+                                              edm::Run const& run,
+                                              edm::EventSetup const& iSetup,
+                                              Histograms_TICLTrackstersValidation& histos) const {
   ibook.setCurrentFolder(folder_ + "TICLTracksters/");
 }
 
-void TICLTrackstersValidation::dqmBeginRun(edm::Run const& run, edm::EventSetup const& iSetup, Histograms_TICLTrackstersValidation & histograms)
-{
-    rhtools_.getEventSetup(iSetup); 
+void TICLTrackstersValidation::dqmBeginRun(edm::Run const& run,
+                                           edm::EventSetup const& iSetup,
+                                           Histograms_TICLTrackstersValidation& histograms) {
+  rhtools_.getEventSetup(iSetup);
 }
 
 void TICLTrackstersValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -100,7 +95,7 @@ void TICLTrackstersValidation::fillDescriptions(edm::ConfigurationDescriptions& 
                                            edm::InputTag("ticlTrackstersHAD"),
                                            edm::InputTag("ticlTrackstersMerge")};
   desc.add<std::vector<edm::InputTag>>("tracksterCollections", source_vector);
-  desc.add<std::string>("folder", "HGCAL/");  
+  desc.add<std::string>("folder", "HGCAL/");
   descriptions.add("ticlTrackstersValidationDefault", desc);
 }
 

--- a/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
+++ b/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
@@ -47,16 +47,13 @@ private:
   hgcal::RecHitTools rhtools_;
 };
 
-
-
 TICLTrackstersValidation::TICLTrackstersValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")) {
-  tracksterTokens_ =
-      edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
-                            [this](edm::InputTag const& tag) { 
-                              trackstersCollectionsNames_.emplace_back(tag.label());
-                              return consumes<std::vector<Trackster>>(tag); 
-                              });
+  tracksterTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
+                                           [this](edm::InputTag const& tag) {
+                                             trackstersCollectionsNames_.emplace_back(tag.label());
+                                             return consumes<std::vector<Trackster>>(tag);
+                                           });
 
   layerClustersToken_ = consumes<std::vector<reco::CaloCluster>>(iConfig.getParameter<edm::InputTag>("layerClusters"));
 }
@@ -66,7 +63,6 @@ TICLTrackstersValidation::~TICLTrackstersValidation() {}
 void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
                                           edm::EventSetup const& iSetup,
                                           Histograms_TICLTrackstersValidation const& histos) const {
-  
   edm::Handle<std::vector<reco::CaloCluster>> layerClustersH;
   iEvent.getByToken(layerClustersToken_, layerClustersH);
   auto const& layerClusters = *layerClustersH.product();
@@ -76,12 +72,10 @@ void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
     auto numberOfTracksters = trackster_h->size();
     //using .at() as [] is not const
     const auto& histo = histos.at(trackster_token.index());
-    for(unsigned int i = 0; i< numberOfTracksters; ++i)
-    {
+    for (unsigned int i = 0; i < numberOfTracksters; ++i) {
       const auto& thisTrackster = trackster_h->at(i);
       histo.energy_->Fill(thisTrackster.regressed_energy());
     }
-
   }
 }
 
@@ -89,7 +83,7 @@ void TICLTrackstersValidation::bookHistograms(DQMStore::IBooker& ibook,
                                               edm::Run const& run,
                                               edm::EventSetup const& iSetup,
                                               Histograms_TICLTrackstersValidation& histos) const {
-  int labelIndex = 0; 
+  int labelIndex = 0;
   for (const auto& trackster_token : tracksterTokens_) {
     auto& histo = histos[trackster_token.index()];
     ibook.setCurrentFolder(folder_ + "TICLTracksters/" + trackstersCollectionsNames_[labelIndex]);
@@ -97,7 +91,6 @@ void TICLTrackstersValidation::bookHistograms(DQMStore::IBooker& ibook,
 
     labelIndex++;
   }
-
 }
 
 void TICLTrackstersValidation::dqmBeginRun(edm::Run const& run,

--- a/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
+++ b/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
@@ -13,6 +13,10 @@
 #include "FWCore/Utilities/interface/transform.h"
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
+
+
 using namespace ticl;
 using namespace edm;
 
@@ -37,17 +41,20 @@ private:
                       Histograms_TICLTrackstersValidation&) const override;
 
   void dqmAnalyze(edm::Event const&, edm::EventSetup const&, Histograms_TICLTrackstersValidation const&) const override;
+  void dqmBeginRun(edm::Run const&, edm::EventSetup const&, Histograms_TICLTrackstersValidation &);
 
   std::string folder_;
-  std::vector<edm::EDGetTokenT<std::vector<Trackster>>> trackster_tokens_;
+  std::vector<edm::EDGetTokenT<std::vector<Trackster>>> tracksterTokens_;
+  edm::EDGetTokenT<std::vector<reco::CaloCluster>> layerClustersToken_;
+  hgcal::RecHitTools rhtools_;
 };
 
 
 TICLTrackstersValidation::TICLTrackstersValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")){
-  trackster_tokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
+  tracksterTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
                             [this](edm::InputTag const& tag) { return consumes<std::vector<Trackster>>(tag); });
-     
+  layerClustersToken_ = consumes<std::vector<reco::CaloCluster>>(iConfig.getParameter<edm::InputTag>("layerClusters"));
 }
 
 TICLTrackstersValidation::~TICLTrackstersValidation() {
@@ -59,7 +66,10 @@ void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
                                   edm::EventSetup const& iSetup,
                                   Histograms_TICLTrackstersValidation const& histos) const {
 
-  for (auto& trackster_token : trackster_tokens_) {
+  edm::Handle<std::vector<reco::CaloCluster>> layerClustersH;
+  iEvent.getByToken(layerClustersToken_, layerClustersH);
+  auto const& layerClusters = *layerClustersH.product();
+  for (auto& trackster_token : tracksterTokens_) {
     edm::Handle<std::vector<Trackster>> trackster_h;
     iEvent.getByToken(trackster_token, trackster_h);
     auto numberOfTracksters = trackster_h->size();
@@ -75,6 +85,11 @@ void TICLTrackstersValidation::bookHistograms(DQMStore::IBooker& ibook,
                                       edm::EventSetup const& iSetup,
                                       Histograms_TICLTrackstersValidation& histos) const {
   ibook.setCurrentFolder(folder_ + "TICLTracksters/");
+}
+
+void TICLTrackstersValidation::dqmBeginRun(edm::Run const& run, edm::EventSetup const& iSetup, Histograms_TICLTrackstersValidation & histograms)
+{
+    rhtools_.getEventSetup(iSetup); 
 }
 
 void TICLTrackstersValidation::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
+++ b/Validation/HGCalValidation/plugins/TICLTrackstersValidation.cc
@@ -17,13 +17,12 @@
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
 using namespace ticl;
-using namespace edm;
 
 struct Histogram_TICLTrackstersValidation {
   dqm::reco::MonitorElement* energy_;
 };
 
-using Histograms_TICLTrackstersValidation = std::unordered_map<int, Histogram_TICLTrackstersValidation>;
+using Histograms_TICLTrackstersValidation = std::unordered_map<unsigned int, Histogram_TICLTrackstersValidation>;
 
 class TICLTrackstersValidation : public DQMGlobalEDAnalyzer<Histograms_TICLTrackstersValidation> {
 public:
@@ -42,16 +41,23 @@ private:
   void dqmBeginRun(edm::Run const&, edm::EventSetup const&, Histograms_TICLTrackstersValidation&);
 
   std::string folder_;
+  std::vector<std::string> trackstersCollectionsNames_;
   std::vector<edm::EDGetTokenT<std::vector<Trackster>>> tracksterTokens_;
   edm::EDGetTokenT<std::vector<reco::CaloCluster>> layerClustersToken_;
   hgcal::RecHitTools rhtools_;
 };
 
+
+
 TICLTrackstersValidation::TICLTrackstersValidation(const edm::ParameterSet& iConfig)
     : folder_(iConfig.getParameter<std::string>("folder")) {
   tracksterTokens_ =
       edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("tracksterCollections"),
-                            [this](edm::InputTag const& tag) { return consumes<std::vector<Trackster>>(tag); });
+                            [this](edm::InputTag const& tag) { 
+                              trackstersCollectionsNames_.emplace_back(tag.label());
+                              return consumes<std::vector<Trackster>>(tag); 
+                              });
+
   layerClustersToken_ = consumes<std::vector<reco::CaloCluster>>(iConfig.getParameter<edm::InputTag>("layerClusters"));
 }
 
@@ -60,17 +66,22 @@ TICLTrackstersValidation::~TICLTrackstersValidation() {}
 void TICLTrackstersValidation::dqmAnalyze(edm::Event const& iEvent,
                                           edm::EventSetup const& iSetup,
                                           Histograms_TICLTrackstersValidation const& histos) const {
+  
   edm::Handle<std::vector<reco::CaloCluster>> layerClustersH;
   iEvent.getByToken(layerClustersToken_, layerClustersH);
   auto const& layerClusters = *layerClustersH.product();
-  for (auto& trackster_token : tracksterTokens_) {
+  for (const auto& trackster_token : tracksterTokens_) {
     edm::Handle<std::vector<Trackster>> trackster_h;
     iEvent.getByToken(trackster_token, trackster_h);
     auto numberOfTracksters = trackster_h->size();
-
-    for (size_t i = 0; i < numberOfTracksters; ++i) {
-      auto const& trackster = (*trackster_h)[i];
+    //using .at() as [] is not const
+    const auto& histo = histos.at(trackster_token.index());
+    for(unsigned int i = 0; i< numberOfTracksters; ++i)
+    {
+      const auto& thisTrackster = trackster_h->at(i);
+      histo.energy_->Fill(thisTrackster.regressed_energy());
     }
+
   }
 }
 
@@ -78,7 +89,15 @@ void TICLTrackstersValidation::bookHistograms(DQMStore::IBooker& ibook,
                                               edm::Run const& run,
                                               edm::EventSetup const& iSetup,
                                               Histograms_TICLTrackstersValidation& histos) const {
-  ibook.setCurrentFolder(folder_ + "TICLTracksters/");
+  int labelIndex = 0; 
+  for (const auto& trackster_token : tracksterTokens_) {
+    auto& histo = histos[trackster_token.index()];
+    ibook.setCurrentFolder(folder_ + "TICLTracksters/" + trackstersCollectionsNames_[labelIndex]);
+    histo.energy_ = ibook.book1D("Regressed Energy", "Energy", 250, 0., 250.);
+
+    labelIndex++;
+  }
+
 }
 
 void TICLTrackstersValidation::dqmBeginRun(edm::Run const& run,
@@ -95,6 +114,7 @@ void TICLTrackstersValidation::fillDescriptions(edm::ConfigurationDescriptions& 
                                            edm::InputTag("ticlTrackstersHAD"),
                                            edm::InputTag("ticlTrackstersMerge")};
   desc.add<std::vector<edm::InputTag>>("tracksterCollections", source_vector);
+  desc.add<edm::InputTag>("layerClusters", edm::InputTag("hgcalLayerClusters"));
   desc.add<std::string>("folder", "HGCAL/");
   descriptions.add("ticlTrackstersValidationDefault", desc);
 }

--- a/Validation/HGCalValidation/python/ticlTrackstersValidation_cfi.py
+++ b/Validation/HGCalValidation/python/ticlTrackstersValidation_cfi.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.HGCalValidation.ticlTrackstersValidationDefault_cfi import ticlTrackstersValidationDefault as _ticlTrackstersValidationDefault
+ticlTrackstersValidation = _ticlTrackstersValidationDefault.clone()


### PR DESCRIPTION
A DQM analyzer was created for plotting Tracksters' properties in different iterations.
It was tested on single particle event and I verified that the placeholder plot for regressed energy is produced correctly in the correct path.